### PR TITLE
Replaced webpack 'loader:' and 'fallbackLoader:' occurences with 'use…

### DIFF
--- a/_bundlers/webpack/webpack.config.js
+++ b/_bundlers/webpack/webpack.config.js
@@ -19,8 +19,8 @@ const dir = path.resolve(`${__dirname}/..`);
 
 // Define environment
 const ENV = process.env.NODE_ENV || 'development';
-const SOURCEMAP = (ENV === 'development');
-const DASHBOARD = (process.env.npm_lifecycle_event === 'dashboard') ? 1 : 0;
+const SOURCEMAP = ENV === 'development';
+const DASHBOARD = process.env.npm_lifecycle_event === 'dashboard' ? 1 : 0;
 
 const webpackConfig = {
   entry: [
@@ -51,9 +51,9 @@ const webpackConfig = {
       {
         test: /\.(css|scss)$/,
         exclude: [path.resolve(__dirname, 'src/components')],
-        loader: ExtractTextPlugin.extract({
-          fallbackLoader: 'style-loader',
-          loader: [
+        use: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use: [
             `css-loader?modules&importLoaders=1&localIdentName=[path][name]_[local]--[hash:base64:5]&sourceMap=${SOURCEMAP}`,
             'postcss-loader',
             'sass-loader',
@@ -65,15 +65,11 @@ const webpackConfig = {
   plugins: [
     new webpack.LoaderOptionsPlugin({
       options: {
-        postcss: () => [
-          postcssNext,
-          postcssLost,
-          postcssReporter,
-        ],
+        postcss: () => [postcssNext, postcssLost, postcssReporter],
       },
     }),
     new webpack.DefinePlugin({
-      __DEV__: (ENV === 'development'),
+      __DEV__: ENV === 'development',
       'process.env': {
         NODE_ENV: JSON.stringify(ENV),
       },
@@ -81,14 +77,17 @@ const webpackConfig = {
   ],
 };
 
-if (process.env.npm_package_config_setup === 'react' || process.env.npm_package_config_setup === 'react-router') {
+if (
+  process.env.npm_package_config_setup === 'react' ||
+  process.env.npm_package_config_setup === 'react-router'
+) {
   webpackConfig.entry.unshift('react-hot-loader/patch');
 }
 
 if (process.env.npm_package_config_setup === 'vue') {
   webpackConfig.module.rules.unshift({
     test: /\.vue$/,
-    loader: 'vue-loader',
+    use: 'vue-loader',
     exclude: '/node_modules/',
   });
 }
@@ -110,17 +109,15 @@ if (ENV === 'development') {
     new ExtractTextPlugin({
       filename: 'style.css',
       allChunks: true,
-      disable: (ENV === 'development'),
+      disable: ENV === 'development',
     }),
     // Enable HMR globally
     new webpack.HotModuleReplacementPlugin(),
-
     // Prints more readable module names in the browser console on HMR updates
     new webpack.NamedModulesPlugin(),
-
     new HtmlWebpackPlugin({
       template: path.resolve(dir, 'templates/index.html'),
-      minify: { collapseWhitespace: true }
+      minify: { collapseWhitespace: true },
     })
   );
 
@@ -129,9 +126,7 @@ if (ENV === 'development') {
 }
 
 if (DASHBOARD && ENV === 'development') {
-  webpackConfig.plugins.unshift(
-    new WebpackDashboard({ port: config.dashboardPort })
-  );
+  webpackConfig.plugins.unshift(new WebpackDashboard({ port: config.dashboardPort }));
 }
 
 if (process.env.npm_package_config_pwa === 'true') {
@@ -147,10 +142,8 @@ if (process.env.npm_package_config_pwa === 'true') {
       },
       {
         from: `${dir}/pwa/service-worker.js`,
-        transform: content => (
-          content.toString().replace('_USECACHE_', false)
-        ),
-      }
+        transform: content => content.toString().replace('_USECACHE_', false),
+      },
     ])
   );
 }

--- a/_bundlers/webpack/webpack.production.config.js
+++ b/_bundlers/webpack/webpack.production.config.js
@@ -25,7 +25,7 @@ const buildDirectoryName = 'dist';
 const distDirectory = path.resolve(dir, buildDirectoryName);
 
 // Export for the env variable
-module.exports = (env) => {
+module.exports = env => {
   let stats = false;
   if (typeof env !== 'undefined') {
     stats = true;
@@ -53,7 +53,6 @@ module.exports = (env) => {
     },
   };
 
-
   webpackSettings.module.rules = [
     {
       test: /\.jsx?$/,
@@ -63,9 +62,9 @@ module.exports = (env) => {
     {
       test: /\.(css|scss)$/,
       exclude: [path.resolve(__dirname, 'src/components')],
-      loader: ExtractTextPlugin.extract({
-        fallbackLoader: 'style-loader',
-        loader: [
+      use: ExtractTextPlugin.extract({
+        fallback: 'style-loader',
+        use: [
           `css-loader?modules&importLoaders=1&localIdentName=[path][name]_[local]--[hash:base64:5]&sourceMap=${SOURCEMAP}`,
           'postcss-loader',
           `sass-loader?sourceMap=${SOURCEMAP}`,
@@ -85,17 +84,13 @@ module.exports = (env) => {
     new webpack.DefinePlugin(globals),
     new webpack.LoaderOptionsPlugin({
       options: {
-        postcss: () => [
-          postcssNext,
-          postcssLost,
-          postcssReporter,
-        ],
+        postcss: () => [postcssNext, postcssLost, postcssReporter],
       },
     }),
     new HtmlWebpackPlugin({
       template: path.resolve(dir, 'templates/index.html'),
-      minify: { collapseWhitespace: true }
-    })
+      minify: { collapseWhitespace: true },
+    }),
   ];
 
   if (stats) {
@@ -151,13 +146,11 @@ module.exports = (env) => {
         },
         {
           from: `${dir}/pwa/service-worker.js`,
-          transform: content => (
-            content.toString().replace('_USECACHE_', true)
-          ),
-        }
+          transform: content => content.toString().replace('_USECACHE_', true),
+        },
       ])
     );
   }
 
   return webpackSettings;
-}
+};


### PR DESCRIPTION
[Extract-text-webpack-plugin applied webpack 3 defaults and dropped support for 'loader' and 'fallbackLoader'.](https://github.com/webpack-contrib/extract-text-webpack-plugin/commit/7ae32d9c560ef0a7dd584e3bf5991bacd5753093#diff-939b6c88924565b1f2a28ada62e3027e). This commit fixes the issues related to that. Also accidentally applied 'Prettier' formatting. 